### PR TITLE
Added custom variable for configuring link prefix

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,3 +50,22 @@ hit =C-M-y=, so we always have to store the current buffer on
 kills. You can remove the =:demand t= and have lazy/deferred loading,
 but then the first time you hit =C-M-y= after startup, you'll get a
 message that you have to kill the selection again.
+
+** Configuring link prefix
+
+If you want to prefix the link to the source location you can do so by defining =org-rich-yank-link-prefix=. For example, links to local files might be useful in your org document but not so useful in exported content, so you may want to make the link a /comment/ line.
+
+#+begin_src emacs-lisp :tangle no
+  (customize-set-variable 'org-rich-yank-link-prefix "#+comment: ")
+#+end_src
+
+Configuring the variable as above results in the following content being pasted:
+
+#+begin_example
+  ,#+BEGIN_SRC emacs-lisp
+  ;; URL: https://github.com/unhammer/org-rich-yank
+  ;; Package-Requires: ((emacs "24.4"))
+  ;; Keywords: convenience, hypermedia, org
+  ,#+END_SRC
+  ,#+comment: [[file:~/src/org-rich-yank/org-rich-yank.el]]
+#+end_example

--- a/org-rich-yank.el
+++ b/org-rich-yank.el
@@ -65,6 +65,15 @@ all lines below will also get that indentation."
   :group 'org-rich-yank
   :type 'boolean)
 
+(defcustom org-rich-yank-link-prefix nil
+  "String to prefix link to source location with.
+If this variable is non-nil the string will be used to prefix the
+link to the source location. For example a value of \"#+comment:
+\" will cause the link to be inserted as a comment that will not
+be exported."
+  :group 'org-rich-yank
+  :type 'string)
+
 (defvar org-rich-yank--buffer nil)
 
 (defun org-rich-yank--store (&rest _args)
@@ -148,7 +157,7 @@ ARGS ignored."
                        (replace-regexp-in-string "-mode$" "" (symbol-name source-mode)))
                (org-rich-yank--trim-nl (current-kill 0))
                (format "\n#+END_SRC\n")
-               (org-rich-yank--link))))
+               (concat org-rich-yank-link-prefix ( org-rich-yank--link )))))
         (insert
          (if org-rich-yank-add-target-indent
              (org-rich-yank-indent paste)


### PR DESCRIPTION
This change makes it easy to give link paths some leading context or convert
them into comments so that they are not exported.

Closes #9