### PR TITLE
Use autoload functions to instead of require entire org package

### DIFF
--- a/org-rich-yank.el
+++ b/org-rich-yank.el
@@ -53,7 +53,8 @@
 
 ;;; Code:
 
-(require 'org)
+(autoload 'org-store-link "ol")
+(autoload 'org-escape-code-in-string "org-src")
 
 (defgroup org-rich-yank nil
   "Options for org-rich-yank."


### PR DESCRIPTION
Hi, 
The `org-rich-yank` will require `org` package which will cause heavy initializte at startup (based on the Spacemacs).

The changes will make it's light before using the `org-mode`. 

Please help review the changes. Thanks