### PR TITLE
Prevent printing "nil" when no link is found

### DIFF
--- a/org-rich-yank.el
+++ b/org-rich-yank.el
@@ -179,7 +179,9 @@ ARGS ignored."
 
 (defun org-rich-yank--format-paste-default (language contents link)
   "Format LANGUAGE, CONTENTS and LINK as an `org-mode' source block."
-  (format "#+BEGIN_SRC %s\n%s\n#+END_SRC\n%s"
+  (setq pattern "#+BEGIN_SRC %s\n%s\n#+END_SRC\n")
+  (if link (setq pattern (concat pattern "%s")))
+  (format pattern
           language
           (org-rich-yank--trim-nl contents)
           link))


### PR DESCRIPTION
Sometimes when yanking from e.g. vterm there is no useful link. This is not an issue, but since https://github.com/unhammer/org-rich-yank/commit/e1566b7d7dd46f04ce08f0f948d108d3d18f4494 this results in a paste like:
```
#+BEGIN_SRC vterm
<something>
#+END_SRC
nil
```

With the proposed changes the link will not be printed if the content is `nil`. Please excuse the poor coding style.